### PR TITLE
Fix handling of C++-aware headers

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -12,7 +12,7 @@ Let's call hammocking without any arguments:
 ..  code-block:: shell
 
     $ python -m hammocking
-    usage: hammocking [-h] (--symbols SYMBOLS [SYMBOLS ...] | --plink PLINK) --outdir OUTDIR --sources SOURCES [SOURCES ...]
+    usage: hammocking [-h] (--symbols SYMBOLS [SYMBOLS ...] | --plink PLINK) --outdir OUTDIR --sources SOURCES [SOURCES ...] [--except EXCLUDES ...]
     hammocking: error: the following arguments are required: --outdir/-o, --sources
 
 hammocking needs ...
@@ -22,6 +22,8 @@ hammocking needs ...
    * --symbols*: comma seperated list of symbol names which are to mock or
    * *--plink*: path to the object file which contains the unresolved symbols to mock
 * *--outdir*: An existing directory where to write code files containing mockup code.
+* *--except*: if a symbol is found in a header of these directories, it will not be mocked. Use this to exclude symbols from mocking that will be provided by libraries in the linking process.
+  (Defaults to ``/usr/include`` for system headers)
 
 One compilation unit
 --------------------

--- a/tests/hammocking_test.py
+++ b/tests/hammocking_test.py
@@ -299,6 +299,19 @@ extern void ignore_me();
         assert len(mock.writer.functions) == 1, "Mockup shall have a function"
         assert mock.writer.functions[0].get_signature() == "void foo()", "Function shall be created in the mockup"
 
+    def test_extern_c_variable(self):
+        """Mock a variable that is inside an "extern C" section"""
+        mock = Hammock(["foo"])
+        mock.parse("""
+extern "C" {
+extern void foo();
+}
+"""
+        )
+        assert mock.done, "Should be done now"
+        assert len(mock.writer.functions) == 1, "Mockup shall have a function"
+        assert mock.writer.functions[0].get_signature() == "void foo()", "Function shall be created in the mockup"
+
     def test_variable_array(self):
         """Mock an int array"""
         mock = Hammock(["my_array"])


### PR DESCRIPTION
- find symbols that are within a `extern "C"` section
- Allow to exclude standard or other lib symbols from mocking