### PR TITLE
feat: add exclude-method

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -43,7 +43,7 @@ function Invoke-CommandLine {
 
 function Invoke-Bootstrap {
     # Download bootstrap scripts from external repository
-    Invoke-RestMethod https://raw.githubusercontent.com/avengineers/bootstrap-installer/v1.16.0/install.ps1 | Invoke-Expression
+    Invoke-RestMethod https://raw.githubusercontent.com/avengineers/bootstrap-installer/v1.17.1/install.ps1 | Invoke-Expression
     # Execute bootstrap script
     . .\.bootstrap\bootstrap.ps1
 }

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -76,3 +76,37 @@ https://google.github.io/googletest/reference/mocking.html
    :code: makefile
    :literal:
    :number-lines:
+
+
+
+Exclude Symbols not found in the project-root-directory
+-------------------------------------------------------
+
+If you want to exclude all symbols that are found outside of your project root directory, you can use the
+*--ignore-symbols-outside-project* option. This is useful to exclude symbols that are provided by the standard libraries. To use this option, you need to additionally specify the project root directory with the *---project-root-dir* option.
+
+Overwrite hammocking default parameters
+---------------------------------------
+
+You can overwrite the default parameters of hammocking by creating a file named `hammocking.ini` in the current working directory. The file should contain the parameters you want to overwrite, in the format:
+
+..  code-block:: ini
+
+   [hammocking]
+   parameter = value
+   [hammocking.<system>]
+   parameter = value
+
+The system depends on the platform you are running on, e.g. `hammocking.linux` for Linux systems. The parameters you can overwrite are:
+
+* clang_lib_file
+* clang_lib_path
+* ignore_path
+* exclude_pattern
+* include_pattern
+* nm_path
+
+If you have created the file you can run hammocking with the `--config` option to specify the path to the configuration file.
+
+Each of these parameters can also be set via command line option. The command line options have precedence over the parameters in the configuration file.
+Please be aware that the `ignore_path` parameter from the configuration file is called `exclude_paths` in the command line options.

--- a/src/hammocking/hammocking.py
+++ b/src/hammocking/hammocking.py
@@ -1,22 +1,92 @@
 #!/usr/bin/env python3
 
 import sys
+from dataclasses import dataclass, field
 from os import listdir
 from os.path import dirname
+
+from mashumaro import DataClassDictMixin
 
 sys.path.append(dirname(__file__))
 
 import configparser
 import logging
 import re
-from argparse import ArgumentParser
+from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Iterable, Iterator, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 
 from clang.cindex import Config, Cursor, CursorKind, Index, TranslationUnit, TypeKind
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from py_app_dev.core.subprocess import SubprocessExecutor
+
+
+@dataclass
+class HammockIni(DataClassDictMixin):
+    """Configuration for Hammock Ini File"""
+
+    clang_lib_file: Optional[str] = None
+    clang_lib_path: Optional[str] = None
+    exclude_paths: Optional[List[str]] = None
+    exclude_pattern: Optional[str] = None
+    include_pattern: Optional[str] = None
+    nm_path: Optional[str] = None
+
+
+@dataclass
+class HammockConfig(DataClassDictMixin):
+    """Configuration for Hammocking"""
+
+    outdir: Path
+    sources: List[Path]
+    symbols: Optional[Set[str]] = None
+    plink: Optional[Path] = None
+    style: Optional[str] = "gmock"
+    suffix: Optional[str] = ""
+    exclude_paths: Optional[List[str]] = None
+    exclude: Optional[List[str]] = field(default_factory=lambda: [])
+    config: Optional[Path] = None
+    exclude_pattern: Optional[str] = None
+    clang_lib_file: Optional[str] = None
+    clang_lib_path: Optional[str] = None
+    include_pattern: Optional[str] = None
+    nm_path: Optional[str] = None
+    ignore_symbols_outside_project: bool = False
+    project_root_dir: Optional[Path] = None
+    cmd_args: Optional[List[str]] = None
+
+    @classmethod
+    def from_namespace(cls, namespace: Namespace) -> "HammockConfig":
+        """
+        Create an instance of this class from a namespace.
+
+        Args:
+            namespace (Namespace): Namespace for the Config.
+
+        Returns:
+            HammockConfig: The instance of this class.
+
+        """
+        return cls.from_dict(vars(namespace))
+
+    def merge(self, hammock_ini: HammockIni) -> "HammockConfig":
+        """
+        Merge the HammockIni configuration into the current HammockConfig instance.
+
+        Args:
+            hammock_ini (HammockIni): The HammockIni instance to merge.
+
+        Returns:
+            None
+        """
+        result: Dict[Any, Any] = {}
+        result = self.to_dict()
+        hammock_ini_dict = hammock_ini.to_dict()
+        for key, value in result.items():
+            if value is None and key in hammock_ini_dict:
+                result[key] = hammock_ini_dict[key]
+        return HammockConfig.from_dict(result)
 
 
 class RenderableType:
@@ -77,31 +147,49 @@ class ConfigReader:
 
     def __init__(self, configfile: Optional[Path] = None):
         if configfile is None or configfile == Path(""):
-            configfile = ConfigReader.configfile
+            self.configfile = ConfigReader.configfile
+        else:
+            self.configfile = configfile
         self.exclude_paths: List[str] = []
-        if not configfile.exists():
+        if not self.configfile.exists():
             return
+        self.hammock_ini = HammockIni()
+
+    def read(self) -> HammockIni:
+        """
+        Read the configuration from the given file.
+
+        Args:
+            configfile (Optional[Path]): The path to the configuration file. If None, the default config file is used.
+
+        Returns:
+            HammockIni: The configuration read from the file.
+        """
         config = configparser.ConfigParser()
-        config.read_string(configfile.read_text())
+        config.read_string(self.configfile.read_text())
         # Read generic settings
         self._scan(config.items(section=self.section))
         # Read OS-specific settings
-        self._scan(config.items(section=f"{self.section}.{sys.platform}"))
+        os_section = f"{self.section}.{sys.platform}"
+        if config.has_section(os_section):
+            logging.debug(f"Reading OS-specific configuration from section: {os_section}")
+        self._scan(config.items(section=os_section))
+        return self.hammock_ini
 
     def _scan(self, items: List[Tuple[str, str]]) -> None:
         for item, value in items:
             if item == "clang_lib_file":
-                Config.set_library_file(value)
+                self.hammock_ini.clang_lib_file = value
             if item == "clang_lib_path":
-                Config.set_library_path(value)
+                self.hammock_ini.clang_lib_path = value
             if item == "nm":
-                NmWrapper.set_nm_path(value)
+                self.hammock_ini.nm_path = value
             if item == "ignore_path":
-                self.exclude_paths = value.split(",")
+                self.hammock_ini.exclude_paths = value.split(",")
             if item == "include_pattern":
-                NmWrapper.set_include_pattern(value)
+                self.hammock_ini.include_pattern = value
             if item == "exclude_pattern":
-                NmWrapper.set_exclude_pattern(value)
+                self.hammock_ini.exclude_pattern = value
 
 
 class Variable:
@@ -239,12 +327,16 @@ class MockupWriter:
 
 
 class Hammock:
-    def __init__(self, symbols: Set[str], cmd_args: Optional[List[str]] = None, mockup_style: str = "gmock", suffix: str = ""):
+    def __init__(
+        self, symbols: Set[str], cmd_args: Optional[List[str]] = None, mockup_style: str = "gmock", suffix: str = "", project_root_dir: Optional[Path] = None, ignore_symbols_outside_project: bool = False
+    ) -> None:
         self.logger = logging.getLogger("Hammocking")
         self.symbols: Set[str] = symbols
         self.cmd_args = cmd_args or []
         self.writer = MockupWriter(mockup_style, suffix)
         self.exclude_paths: List[str] = []
+        self.project_root_dir = project_root_dir
+        self.ignore_symbols_outside_project = ignore_symbols_outside_project
 
     def add_excludes(self, paths: Iterable[str]) -> None:
         self.exclude_paths.extend(paths)
@@ -294,6 +386,8 @@ class Hammock:
             if child.spelling in self.symbols:
                 if any(child.location.file.name.startswith(prefix) for prefix in self.exclude_paths):
                     self.logger.info(f"Skipping symbol {child.spelling} due to exclude path: {child.location.file}")
+                elif self.ignore_symbols_outside_project and self.project_root_dir and self.project_root_dir.resolve() not in Path(child.location.file.name).resolve().parents:
+                    self.logger.info(f"Skipping symbol {child.spelling} because it is not in the project: {child.location.file}")
                 else:
                     in_header = child.location.file.name != translation_unit.spelling
                     if in_header:
@@ -387,6 +481,63 @@ class NmWrapper:
         return None
 
 
+class HammockRunner:
+    def __init__(self, hammock_config: HammockConfig):
+        self.hammock_config = hammock_config
+        if self.hammock_config.config and self.hammock_config.config.exists():
+            ini_config = ConfigReader(self.hammock_config.config)
+        else:
+            ini_config = ConfigReader()
+        if ini_config:
+            hammock_ini = ini_config.read()
+            self.hammock_config = self.hammock_config.merge(hammock_ini)
+        self.update_system()
+
+    def update_system(self) -> None:
+        if self.hammock_config.clang_lib_file:
+            if not Config.loaded:
+                Config.set_library_file(self.hammock_config.clang_lib_file)
+        if self.hammock_config.clang_lib_path:
+            if not Config.loaded:
+                Config.set_library_path(self.hammock_config.clang_lib_path)
+        if self.hammock_config.nm_path:
+            NmWrapper.set_nm_path(self.hammock_config.nm_path)
+        if self.hammock_config.include_pattern:
+            NmWrapper.set_include_pattern(self.hammock_config.include_pattern)
+        if self.hammock_config.exclude_pattern:
+            NmWrapper.set_exclude_pattern(self.hammock_config.exclude_pattern)
+
+    def run(self) -> int:
+        if self.hammock_config.plink and not self.hammock_config.symbols:
+            self.hammock_config.symbols = NmWrapper(self.hammock_config.plink).get_undefined_symbols()
+
+        if self.hammock_config.symbols and self.hammock_config.exclude:
+            self.hammock_config.symbols -= set(self.hammock_config.exclude)
+
+        self.hammock = Hammock(
+            symbols=self.hammock_config.symbols if self.hammock_config.symbols else set(),
+            cmd_args=self.hammock_config.cmd_args if self.hammock_config.cmd_args else [],
+            mockup_style=self.hammock_config.style if self.hammock_config.style else "gmock",
+            suffix=self.hammock_config.suffix if self.hammock_config.suffix else "",
+            ignore_symbols_outside_project=self.hammock_config.ignore_symbols_outside_project if self.hammock_config.ignore_symbols_outside_project else False,
+            project_root_dir=self.hammock_config.project_root_dir if self.hammock_config.project_root_dir else None,
+        )
+        self.hammock.add_excludes(self.hammock_config.exclude_paths if self.hammock_config.exclude_paths else [])
+        self.hammock.read(self.hammock_config.sources)
+        self.hammock.write(self.hammock_config.outdir)
+
+        if self.hammock.done:
+            logging.info("Hammocking finished successfully.")
+            return 0
+        else:
+            logging.error("Hammocking failed. The following symbols could not be mocked:\n" + "\n".join(self.hammock.symbols))
+            return 1
+
+    def get_symbols(self) -> List[str]:
+        """Get the symbols that could not be mocked."""
+        return list(self.hammock.symbols) if self.hammock else []
+
+
 def main(pargv: List[str]) -> None:
     arg = ArgumentParser(fromfile_prefix_chars="@", prog="hammocking")
 
@@ -403,25 +554,24 @@ def main(pargv: List[str]) -> None:
     arg.add_argument("--except", help="Path prefixes that should not be mocked", nargs="*", dest="exclude_pathes", default=["/usr/include"])
     arg.add_argument("--exclude", help="Symbols that should not be mocked", nargs="*", default=[])
     arg.add_argument("--config", help="Configuration file", required=False, default="")
+    arg.add_argument("--exclude-pattern", help="Exclude symbols matching this pattern", required=False)
+    arg.add_argument("--clang-lib-file", help="Path to the Clang library file", required=False)
+    arg.add_argument("--clang-lib-path", help="Path to the Clang library directory", required=False)
+    arg.add_argument("--nm-path", help="Path to the nm command", required=False)
+    arg.add_argument("--include-pattern", help="Include symbols matching this pattern", required=False)
+    arg.add_argument("--ignore-symbols-outside-project", help="Used to exclude symbols not found in the project-root-directory.", default=False, action="store_true", required=False)
+    arg.add_argument("--project-root-dir", help="Path to the project root directory", type=Path, required=False)
     args, cmd_args = arg.parse_known_args(args=pargv)
 
+    args.cmd_args = cmd_args
+
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
-    config = ConfigReader(Path(args.config))
-    args.exclude_pathes += config.exclude_paths
-    if not args.symbols:
-        args.symbols = NmWrapper(args.plink).get_undefined_symbols()
-
-    args.symbols -= set(args.exclude)
-
-    logging.debug("Extra arguments: %s" % cmd_args)
-
-    h = Hammock(symbols=args.symbols, cmd_args=cmd_args, mockup_style=args.style, suffix=args.suffix)
-    h.add_excludes(args.exclude_pathes)
-    h.read(args.sources)
-    h.write(args.outdir)
-
-    if not h.done:
-        sys.stderr.write("Hammocking failed. The following symbols could not be mocked:\n" + "\n".join(h.symbols) + "\n")
+    logging.debug(f"Extra arguments: {args.cmd_args}")
+    hammock_config = HammockConfig.from_namespace(args)
+    hammock_runner = HammockRunner(hammock_config)
+    result = hammock_runner.run()
+    if result != 0:
+        sys.stderr.write("Hammocking failed. The following symbols could not be mocked:\n" + "\n".join(hammock_runner.get_symbols()) + "\n")
         exit(1)
     exit(0)
 

--- a/tests/test_hammocking.py
+++ b/tests/test_hammocking.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from clang.cindex import Cursor, CursorKind, Index, TranslationUnit
 
-from hammocking.hammocking import ConfigReader, Function, Hammock, MockupWriter, Variable
+from hammocking.hammocking import ConfigReader, Function, Hammock, HammockConfig, HammockRunner, MockupWriter, Variable
 
 # Apply default config
 ConfigReader()
@@ -603,3 +603,64 @@ extern void foo();
         assert hammock.done, "Should be done now"
         assert len(hammock.writer.functions) == 1, "Mockup shall have a function"
         assert hammock.writer.functions[0].get_signature() == "int printf(const char * format, ...)", "Function shall be created in the mockup"
+
+    def test_ignore(self, tmp_path: Path) -> None:
+        """Ignore symbols outside the project root directory"""
+        c_file = tmp_path / "test.c"
+        # copy mini_c_test/b.c to tmp path
+        c_file.write_text(Path("tests/data/mini_c_test/b.c").read_text())
+        # check without exclude method
+        hammock = Hammock(symbols={"a_get_y2", "a_y1"}, cmd_args=["-Itests/data/mini_c_test/includes", "-x", "c"])
+        hammock.parse(c_file)
+        assert hammock.done
+        assert len(hammock.writer.variables) == 1, "Mockup shall have a variable"
+        assert len(hammock.writer.functions) == 1, "Mockup shall have a function"
+
+        # check with exclude method
+        hammock = Hammock(symbols={"a_get_y2", "a_y1"}, cmd_args=["-Itests/data/mini_c_test/includes", "-x", "c"], ignore_symbols_outside_project=True, project_root_dir=Path("some_dir"))
+        hammock.parse(c_file)
+        assert hammock.done
+        assert len(hammock.writer.variables) == 0, "Mockup shall not have a variable"
+        assert len(hammock.writer.functions) == 0, "Mockup shall not have a function"
+
+
+class TestHammockRunner:
+    def test_init(self, tmp_path: Path) -> None:
+        hammock_ini = tmp_path / "hammock.ini"
+        hammock_ini.write_text("""
+[hammocking]
+# nm=nm
+# include_pattern=....
+exclude_pattern=^(_|llvm_|memcmp|memcpy|memset|bzero|exp|strlen)
+[hammocking.linux]
+ignore_path=some_include_dir
+clang_lib_file=libclang.so
+[hammocking.win32]
+ignore_path=some_include_dir
+""")
+        hammock_config = HammockConfig(
+            sources=[
+                Path("tests/data/mini_c_test/b.c"),
+            ],
+            outdir=Path("tests/data/mini_c_test/build"),
+            symbols={"a_y1", "a_get_y2"},
+            cmd_args=["-IC:/D/Git/avengineers/hammocking/tests/data/mini_c_test/includes", "-x", "c"],
+            exclude_pattern=r"^(_|llvm_|memcmp|memcpy|memset)",
+            config=hammock_ini,
+        )
+        hammock = HammockRunner(hammock_config)
+        assert hammock.hammock_config.exclude_paths == ["some_include_dir"]
+        assert hammock.hammock_config.exclude_pattern == r"^(_|llvm_|memcmp|memcpy|memset)"
+        assert hammock.hammock_config.ignore_symbols_outside_project is False
+
+    def test_run(self, tmp_path: Path) -> None:
+        hammock_config = HammockConfig(
+            sources=[
+                Path("tests/data/mini_c_test/b.c"),
+            ],
+            outdir=tmp_path,
+            symbols={"a_y1", "a_get_y2"},
+            cmd_args=["-Itests/data/mini_c_test/includes", "-x", "c"],
+        )
+        hammock = HammockRunner(hammock_config)
+        assert hammock.run() == 0


### PR DESCRIPTION
Add option '--ignore-symbols-outside-project' to ignore all symbols not found in the given project-root-directory
Parameters shall either come from command-line or from ini-file