### PR TITLE
fix: merge project ini over defaults

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,42 +2,82 @@
 
 ## Command line
 
-Before we integrate it into the build chain of your choice it is a good idea to call it on the command line
-in order to gather more understanding what it does and what it needs.
-
-Let's call hammocking without any arguments:
+Before integrating hammocking into your build system, try it on the command line to understand what it does and what it needs.
 
 ```shell
-$ python -m hammocking
-usage: hammocking [-h] (--symbols SYMBOLS [SYMBOLS ...] | --plink PLINK) --outdir OUTDIR --sources SOURCES [SOURCES ...] [--except EXCLUDES ...]
-hammocking: error: the following arguments are required: --outdir/-o, --sources
+python -m hammocking --sources <source files> --plink <object file> --outdir <output dir>
 ```
 
-hammocking needs ...
+### Required arguments
 
-* *--sources*: The list of paths to source files which represent your item-under test. (In classic unittest it is just one)
-* Either ...
-   * --symbols*: comma separated list of symbol names which are to mock or
-   * *--plink*: path to the object file which contains the unresolved symbols to mock
-* *--outdir*: An existing directory where to write code files containing mockup code.
-* *--except*: if a symbol is found in a header of these directories, it will not be mocked. Use this to exclude symbols from mocking that will be provided by libraries in the linking process.
-  (Defaults to `/usr/include` for system headers)
+| Argument | Description |
+|----------|-------------|
+| `--sources` | Source files of the unit under test. Hammocking parses these to find symbol declarations. |
+| `--outdir`, `-o` | Directory where generated mock files are written. Must exist. |
+
+Plus **one** of these (mutually exclusive):
+
+| Argument | Description |
+|----------|-------------|
+| `--symbols`, `-s` | Space-separated list of symbol names to mock. |
+| `--plink`, `-p` | Path to a partially linked object file. Hammocking extracts undefined symbols from it using `nm`. |
+
+### Optional arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--style`, `-t` | `gmock` | Output style for generated mocks. See [Mock output styles](#mock-output-styles). |
+| `--suffix` | *(empty)* | Suffix added to generated filenames (e.g. `_mock` produces `mockup_mock.cc`). |
+| `--config` | *(none)* | Path to a project-level `hammocking.ini`. See [Configuration](#configuration). |
+| `--except` | `/usr/include` | Path prefixes to exclude from symbol search. Symbols found in headers under these paths are not mocked. |
+| `--exclude` | *(none)* | Specific symbol names to skip, even if they appear as undefined. |
+| `--exclude-pattern` | *(from config)* | Regex pattern — matching symbols from `nm` output are skipped. |
+| `--include-pattern` | *(none)* | Regex pattern — only matching symbols are considered. Takes precedence over `--exclude-pattern`. |
+| `--clang-lib-file` | *(auto)* | Filename of the libclang shared library (e.g. `libclang.so`). |
+| `--clang-lib-path` | *(auto)* | Directory containing the libclang shared library. |
+| `--nm-path` | `nm` | Path to the `nm` tool. |
+| `--ignore-symbols-outside-project` | `true` | Skip symbols whose declarations are outside `--project-root-dir`. |
+| `--project-root-dir` | *(none)* | Project root directory. Required for `--ignore-symbols-outside-project`. |
+| `--debug`, `-d` | `false` | Enable debug logging. |
+
+Any additional arguments not listed here are passed through to libclang (e.g. `-I<path>` for include directories, `-x c` to force C language mode).
+
+(mock-output-styles)=
+## Mock output styles
+
+Hammocking supports two output styles, selected via `--style`:
+
+| Style | Files generated | Use case |
+|-------|-----------------|----------|
+| `gmock` (default) | `mockup.cc`, `mockup.h` | C++ test frameworks with Google Mock. Functions are wrapped as `MOCK_METHOD`, variables as extern definitions. |
+| `plain_c` | `mockup.c`, `mockup.h` | Pure C test environments. Functions are generated as simple stubs, variables as plain definitions. |
 
 ## One compilation unit
 
-We show this scenario for explanation purpose only. The next chapter shows the common way and covers the one compilation unit as well.
-
-In a simple scenario your
+This scenario is shown for explanation purposes. The next chapter covers both single and multiple compilation units.
 
 ![Usage One Compile Unit Only](diagrams/usage_one_compile_unit_only.uxf.svg)
 
 ### Make
 
 ```makefile
-# See usage/examples/one_compile_unit/Makefile
+CC := gcc -c
+LD := gcc
+CC_OPTS := -g
+
+a_test.exe: a.c.obj a_test.c.obj mockup.c.obj
+	$(LD) $(CC_OPTS) -o $@ $^
+
+%.c.obj: %.c
+	$(CC) $(CC_OPTS) -MMD -o $@ $<
+
+mockup.c: a.c.obj
+	python -m hammocking --sources a.c --plink a.c.obj --style plain_c --outdir . $(CC_OPTS)
 ```
 
 ### CMake
+
+For a single compilation unit, the CMake setup is the same as for multiple units below — just with a single source file in the `OBJECT` library.
 
 ## One or more compilation units
 
@@ -46,28 +86,146 @@ In a simple scenario your
 ### Make
 
 ```makefile
-# See usage/examples/one_or_more_compile_units/Makefile
+CC := gcc -c
+LD := gcc
+CC_OPTS := -g
+
+a_test.exe: a_1.c.obj a_2.c.obj a_test.c.obj mockup.c.obj
+	$(LD) $(CC_OPTS) -o $@ $^
+
+%.c.obj: %.c
+	$(CC) $(CC_OPTS) -MMD -o $@ $<
+
+# Partially link all production objects into one file
+a.obj: a_1.c.obj a_2.c.obj
+	$(LD) -r -nostdlib -o $@ $^
+
+# Generate mocks from the partially linked object
+mockup.c: a.obj
+	python -m hammocking --sources a_1.c a_2.c --plink a.obj --style plain_c --outdir . $(CC_OPTS)
 ```
 
 ### CMake
 
-## Usage with GoogleTest and GoogleMocks
-
-https://google.github.io/googletest/reference/mocking.html
-
 ```cmake
-# See tests/data/mini_c_test/CMakeLists.txt
+project(a_test)
+cmake_minimum_required(VERSION 3.0)
+
+add_library(a OBJECT a_1.c a_2.c)
+get_target_property(HAMMOCKING_SOURCES a SOURCES)
+
+# Partially link production objects
+set(PROD_PARTIAL_LINK a.obj)
+add_custom_command(
+    OUTPUT ${PROD_PARTIAL_LINK}
+    COMMAND ${CMAKE_C_COMPILER} -r -nostdlib -o ${PROD_PARTIAL_LINK} $<TARGET_OBJECTS:a>
+    COMMAND_EXPAND_LISTS
+    VERBATIM
+    DEPENDS $<TARGET_OBJECTS:a>
+)
+
+# Generate mocks
+add_custom_command(
+    OUTPUT mockup.c
+    BYPRODUCTS mockup.h
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    COMMAND python -m hammocking
+        --sources ${HAMMOCKING_SOURCES}
+        --plink ${CMAKE_CURRENT_BINARY_DIR}/${PROD_PARTIAL_LINK}
+        --style plain_c
+        --outdir ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${PROD_PARTIAL_LINK}
+)
+
+add_executable(a_test mockup.c a_test.c)
+target_link_libraries(a_test a)
+target_include_directories(a_test PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}
+)
 ```
 
-## Exclude Symbols not found in the project-root-directory
+## Usage with Google Test and Google Mock
 
-Hammocking ignores symbols found outside of your project root directory by default. This filters out symbols provided by standard libraries or system headers. The feature requires the project root directory to be specified with the *--project-root-dir* option.
+When using [Google Test](https://google.github.io/googletest/) with [Google Mock](https://google.github.io/googletest/reference/mocking.html), use `--style gmock` (the default). This generates `mockup.cc` with `MOCK_METHOD` wrappers and a `mockup.h` header.
 
-To opt out of this behavior, set `ignore_symbols_outside_project=false` in your `hammocking.ini` configuration file, or pass `--no-ignore-symbols-outside-project` on the command line (not yet supported — use the config file).
+```cmake
+# Fetch Google Test
+include(FetchContent)
+FetchContent_Declare(googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.12.1
+)
+FetchContent_MakeAvailable(googletest)
 
-## Overwrite hammocking default parameters
+include(GoogleTest)
+enable_testing()
 
-You can overwrite the default parameters of hammocking by creating a file named `hammocking.ini` in the current working directory. The file should contain the parameters you want to overwrite, in the format:
+# Production code as OBJECT library
+add_library(prodlib OBJECT b.c)
+
+# Partially link
+set(PROD_PARTIAL_LINK prod.obj)
+add_custom_command(
+    OUTPUT ${PROD_PARTIAL_LINK}
+    COMMAND ${CMAKE_CXX_COMPILER} -r -nostdlib -o ${PROD_PARTIAL_LINK} $<TARGET_OBJECTS:prodlib>
+    COMMAND_EXPAND_LISTS
+    VERBATIM
+    DEPENDS $<TARGET_OBJECTS:prodlib>
+)
+
+# Generate gmock-style mocks
+add_custom_command(
+    OUTPUT mockup.cc
+    BYPRODUCTS mockup.h
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    COMMAND python -m hammocking
+        --sources b.c
+        --plink ${CMAKE_CURRENT_BINARY_DIR}/${PROD_PARTIAL_LINK}
+        --outdir ${CMAKE_CURRENT_BINARY_DIR}
+        "-I$<JOIN:$<TARGET_PROPERTY:prodlib,INCLUDE_DIRECTORIES>,;-I>"
+    DEPENDS ${PROD_PARTIAL_LINK}
+)
+
+# Test executable
+add_executable(my_test mockup.cc b_test.cc)
+target_link_libraries(my_test prodlib GTest::gtest_main GTest::gmock_main)
+gtest_discover_tests(my_test)
+```
+
+## Exclude symbols outside the project root
+
+Hammocking ignores symbols whose declarations are found outside your project root directory by default. This filters out symbols provided by standard libraries or system headers.
+
+To use this feature, specify the project root with `--project-root-dir`:
+
+```shell
+python -m hammocking --sources src/my_module.c --plink build/my_module.obj \
+    --outdir build/ --project-root-dir /path/to/my/project
+```
+
+To opt out, set `ignore_symbols_outside_project=false` in your `hammocking.ini` configuration file.
+
+(configuration)=
+## Configuration
+
+Hammocking ships with a built-in default `hammocking.ini` that provides sensible defaults for all platforms. You can override individual settings by providing a project-level configuration file.
+
+### How configuration merging works
+
+Hammocking always loads its **built-in defaults first**, then overlays your project configuration on top. This means your project config only needs to contain the settings you want to change — everything else falls back to the defaults.
+
+The priority order (highest wins):
+
+1. **Command line options** — always win
+2. **Project `hammocking.ini`** — provided via `--config`
+3. **Built-in defaults** — shipped with the package
+
+For example, if the built-in default sets `exclude_pattern=^(_|llvm_|memcpy|...)` and your project config only sets `ignore_symbols_outside_project=true`, the default `exclude_pattern` remains active.
+
+### Project configuration file
+
+Create a file named `hammocking.ini` with the settings you want to override:
 
 ```ini
 [hammocking]
@@ -76,17 +234,33 @@ parameter = value
 parameter = value
 ```
 
-The system depends on the platform you are running on, e.g. `hammocking.linux` for Linux systems. The parameters you can overwrite are:
+The `<system>` section depends on the platform you are running on, e.g. `hammocking.linux` for Linux, `hammocking.win32` for Windows, or `hammocking.darwin` for macOS. Platform-specific settings override the generic `[hammocking]` section.
 
-* clang_lib_file
-* clang_lib_path
-* ignore_path
-* exclude_pattern
-* include_pattern
-* nm_path
-* ignore_symbols_outside_project (default: `true`)
+Pass it to hammocking with the `--config` option:
 
-If you have created the file you can run hammocking with the `--config` option to specify the path to the configuration file.
+```shell
+python -m hammocking --config path/to/hammocking.ini ...
+```
 
-Each of these parameters can also be set via command line option. The command line options have precedence over the parameters in the configuration file.
-Please be aware that the `ignore_path` parameter from the configuration file is called `exclude_paths` in the command line options.
+### Available parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `clang_lib_file` | *(none)* | Filename of the libclang shared library |
+| `clang_lib_path` | *(platform-specific)* | Directory containing the libclang shared library |
+| `ignore_path` | *(platform-specific)* | Comma-separated list of paths to exclude from symbol search (called `exclude_paths` on the command line) |
+| `exclude_pattern` | `^(_\|llvm_\|memcpy\|memmove\|memset\|memcmp\|bzero\|strlen)` | Regex pattern — matching symbols from `nm` output are skipped. Filters out compiler-generated runtime symbols that should not be mocked. |
+| `include_pattern` | *(none)* | Regex pattern — only matching symbols are considered. Takes precedence over `exclude_pattern`. |
+| `nm` | `nm` | Path to the `nm` tool for extracting undefined symbols |
+| `ignore_symbols_outside_project` | `true` | When `true`, symbols found outside the project root directory are ignored |
+
+Each of these parameters can also be set via command line option. Command line options always take precedence over configuration file values.
+
+### Default exclude_pattern
+
+The built-in `exclude_pattern` filters out symbols that compilers (especially GCC) generate implicitly, such as calls to `memcpy` for struct copies or `memset` for zero-initialization. These are runtime library functions, not real dependencies of your code.
+
+If you need to mock one of these filtered symbols, you have two options:
+
+* Use `include_pattern` in your project config — it takes precedence over `exclude_pattern`
+* Override `exclude_pattern` in your project config with a narrower pattern

--- a/src/hammocking/hammocking.ini
+++ b/src/hammocking/hammocking.ini
@@ -2,7 +2,7 @@
 # nm=nm
 # include_pattern=....
 ignore_symbols_outside_project=true
-exclude_pattern=^(_|llvm_|memcmp|memcpy|memset|bzero|exp|strlen)
+exclude_pattern=^(_|llvm_|memcpy|memmove|memset|memcmp|bzero|strlen)
 [hammocking.darwin]
 ignore_path=/Applications/Xcode.app
 clang_lib_path=/Library/Developer/CommandLineTools/usr/lib

--- a/src/hammocking/hammocking.py
+++ b/src/hammocking/hammocking.py
@@ -35,6 +35,14 @@ class HammockIni(DataClassDictMixin):
     nm_path: str | None = None
     ignore_symbols_outside_project: bool | None = None
 
+    def merge(self, override: "HammockIni") -> "HammockIni":
+        """Overlay non-None values from *override* on top of this instance."""
+        result = self.to_dict()
+        for key, value in override.to_dict().items():
+            if value is not None:
+                result[key] = value
+        return HammockIni.from_dict(result)
+
 
 @dataclass
 class HammockConfig(DataClassDictMixin):
@@ -488,13 +496,12 @@ class HammockRunner:
     def __init__(self, hammock_config: HammockConfig):
         self.hammock_config = hammock_config
         self.hammock: Hammock | None = None
+        # Always load package defaults first, then overlay project config
+        hammock_ini = ConfigReader().read()
         if self.hammock_config.config and self.hammock_config.config.exists():
-            ini_config = ConfigReader(self.hammock_config.config)
-        else:
-            ini_config = ConfigReader()
-        if ini_config:
-            hammock_ini = ini_config.read()
-            self.hammock_config = self.hammock_config.merge(hammock_ini)
+            project_ini = ConfigReader(self.hammock_config.config).read()
+            hammock_ini = hammock_ini.merge(project_ini)
+        self.hammock_config = self.hammock_config.merge(hammock_ini)
         if self.hammock_config.ignore_symbols_outside_project is None:
             self.hammock_config.ignore_symbols_outside_project = True
         self.update_system()

--- a/tests/test_hammocking.py
+++ b/tests/test_hammocking.py
@@ -1,9 +1,10 @@
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
 from clang.cindex import Cursor, CursorKind, Index, TranslationUnit
 
-from hammocking.hammocking import ConfigReader, Function, Hammock, HammockConfig, HammockRunner, MockupWriter, NmWrapper, Variable
+from hammocking.hammocking import ConfigReader, Function, Hammock, HammockConfig, HammockIni, HammockRunner, MockupWriter, NmWrapper, Variable
 
 # Apply default config
 ConfigReader()
@@ -702,6 +703,22 @@ class TestConfigReader:
         assert result.exclude_pattern == "^_"
         assert result.ignore_symbols_outside_project is True
 
+    def test_merge_overlays_non_none_values(self) -> None:
+        """HammockIni.merge() shall overlay non-None values from override, keeping defaults for None values."""
+        default = HammockIni(exclude_pattern="^(_|llvm_)", exclude_paths=["/usr/include"])
+        override = HammockIni(ignore_symbols_outside_project=True)
+        merged = default.merge(override)
+        assert merged.exclude_pattern == "^(_|llvm_)"
+        assert merged.exclude_paths == ["/usr/include"]
+        assert merged.ignore_symbols_outside_project is True
+
+    def test_merge_override_replaces_default(self) -> None:
+        """HammockIni.merge() shall replace default values with override values when both are set."""
+        default = HammockIni(exclude_pattern="^default")
+        override = HammockIni(exclude_pattern="^override")
+        merged = default.merge(override)
+        assert merged.exclude_pattern == "^override"
+
 
 class TestHammockRunner:
     def test_init(self, tmp_path: Path) -> None:
@@ -745,6 +762,16 @@ ignore_path=some_include_dir
         config = HammockConfig(sources=[], outdir=tmp_path, config=hammock_ini, ignore_symbols_outside_project=False)
         runner = HammockRunner(config)
         assert runner.hammock_config.ignore_symbols_outside_project is False
+
+    def test_project_config_preserves_default_exclude_pattern(self, tmp_path: Path) -> None:
+        """A project config that only sets one field must not lose the default exclude_pattern."""
+        project_ini = tmp_path / "hammock.ini"
+        project_ini.write_text("[hammocking]\nignore_symbols_outside_project=true\n")
+        config = HammockConfig(sources=[], outdir=tmp_path, config=project_ini)
+        runner = HammockRunner(config)
+        assert runner.hammock_config.exclude_pattern is not None, "Default exclude_pattern lost when project config was provided"
+        assert runner.hammock_config.exclude_pattern == "^(_|llvm_|memcpy|memmove|memset|memcmp|bzero|strlen)"
+        assert runner.hammock_config.ignore_symbols_outside_project is True
 
     def test_run(self, tmp_path: Path) -> None:
         hammock_config = HammockConfig(
@@ -808,3 +835,53 @@ ignore_path=some_include_dir
         config = HammockConfig(sources=[], outdir=tmp_path)
         runner = HammockRunner(config)
         assert runner.get_symbols() == []
+
+
+class TestNmWrapperMockIt:
+    """Tests for NmWrapper.mock_it() symbol filtering logic."""
+
+    @pytest.fixture(autouse=True)
+    def _save_and_restore_nm_state(self) -> Generator[None, None, None]:
+        """Save and restore NmWrapper class-level state around each test."""
+        original_exclude = NmWrapper.excludepattern
+        original_include = NmWrapper.includepattern
+        yield
+        NmWrapper.excludepattern = original_exclude
+        NmWrapper.includepattern = original_include
+
+    def test_accepts_normal_undefined_symbol(self) -> None:
+        """A regular undefined symbol shall be returned by mock_it()."""
+        NmWrapper.set_exclude_pattern("^__gcov")
+        assert NmWrapper.mock_it("         U my_function") == "my_function"
+
+    def test_rejects_excluded_symbol(self) -> None:
+        """A symbol matching exclude_pattern shall be filtered out."""
+        NmWrapper.set_exclude_pattern("^__gcov")
+        assert NmWrapper.mock_it("         U __gcov_merge_add") is None
+
+    def test_rejects_non_undefined_symbol(self) -> None:
+        """Lines that are not undefined symbols (no 'U') shall be ignored."""
+        assert NmWrapper.mock_it("00000000 T my_function") is None
+
+    def test_include_pattern_overrides_exclude(self) -> None:
+        """include_pattern shall take precedence over exclude_pattern."""
+        NmWrapper.set_exclude_pattern("^mem")
+        NmWrapper.set_include_pattern("^memcpy$")
+        assert NmWrapper.mock_it("         U memcpy") == "memcpy"
+        assert NmWrapper.mock_it("         U memset") is None
+
+    @pytest.mark.parametrize("symbol", ["memcpy", "memmove", "memset", "memcmp", "bzero", "strlen"])
+    def test_default_exclude_pattern_filters_compiler_intrinsics(self, symbol: str) -> None:
+        """The default exclude_pattern from hammocking.ini shall filter common compiler-generated symbols."""
+        default_ini = ConfigReader().read()
+        assert default_ini.exclude_pattern is not None
+        NmWrapper.set_exclude_pattern(default_ini.exclude_pattern)
+        assert NmWrapper.mock_it(f"         U {symbol}") is None, f"{symbol} should be excluded by default pattern"
+
+    @pytest.mark.parametrize("symbol", ["my_app_function", "sensor_read", "can_transmit"])
+    def test_default_exclude_pattern_allows_application_symbols(self, symbol: str) -> None:
+        """The default exclude_pattern shall not filter regular application symbols."""
+        default_ini = ConfigReader().read()
+        assert default_ini.exclude_pattern is not None
+        NmWrapper.set_exclude_pattern(default_ini.exclude_pattern)
+        assert NmWrapper.mock_it(f"         U {symbol}") == symbol, f"{symbol} should not be excluded"


### PR DESCRIPTION
Project-level hammocking.ini via --config completely replaced the built-in defaults instead of overlaying. This caused critical settings like exclude_pattern to be lost, breaking builds with GCC/MinGW where runtime symbols like _pei386_runtime_relocator leaked through.

- Add HammockIni.merge() to overlay non-None values on top of defaults
- HammockRunner always loads package defaults first, then project config
- Extend default exclude_pattern with memcpy, memmove, memset, memcmp, bzero, strlen (compiler-generated intrinsics)
- Rewrite docs/usage.md: complete CLI reference, config merge docs, output styles, real build examples
- Add NmWrapper.mock_it() unit tests for symbol filtering logic