### PR TITLE
fix: detect typedef-aliased arrays and their const qualifier

### DIFF
--- a/src/hammocking/hammocking.py
+++ b/src/hammocking/hammocking.py
@@ -122,14 +122,17 @@ class RenderableType:
     @property
     def is_constant(self) -> bool:
         if self.is_array:
-            return self.t.element_type.is_const_qualified()
+            if self.t.kind in (TypeKind.CONSTANTARRAY, TypeKind.INCOMPLETEARRAY, TypeKind.VARIABLEARRAY, TypeKind.DEPENDENTSIZEDARRAY):
+                return self.t.element_type.is_const_qualified()
+            # Typedef-to-array: const qualifies the typedef, not the element
+            return self.t.is_const_qualified()
         else:
             return self.t.is_const_qualified()
 
     @property
     def is_array(self) -> bool:
-        # many array kinds will make problems, but they are array types.
-        return self.t.kind == TypeKind.CONSTANTARRAY or self.t.kind == TypeKind.INCOMPLETEARRAY or self.t.kind == TypeKind.VARIABLEARRAY or self.t.kind == TypeKind.DEPENDENTSIZEDARRAY
+        array_kinds = (TypeKind.CONSTANTARRAY, TypeKind.INCOMPLETEARRAY, TypeKind.VARIABLEARRAY, TypeKind.DEPENDENTSIZEDARRAY)
+        return self.t.kind in array_kinds or self.t.get_canonical().kind in array_kinds
 
     @property
     def is_struct(self) -> bool:

--- a/tests/test_hammocking.py
+++ b/tests/test_hammocking.py
@@ -109,6 +109,32 @@ class TestVariable:
         assert w.get_definition() == "int *const y"
         assert w.initializer() == "(int *const)0"
 
+    def test_typedef_array(self):
+        "Typedef to a constant-size array"
+        w = Variable(
+            clang_parse("""
+            typedef unsigned char uint8;
+            typedef uint8 Foo[4];
+            extern Foo bar;""")
+        )
+        assert w.name == "bar"
+        assert w._type.is_array
+        assert not w.is_constant()
+        assert w.initializer() == "{0}"
+
+    def test_const_typedef_array(self):
+        "Const variable whose typedef resolves to an array"
+        w = Variable(
+            clang_parse("""
+            typedef unsigned char uint8;
+            typedef uint8 Foo[4];
+            extern const Foo bar;""")
+        )
+        assert w.name == "bar"
+        assert w._type.is_array
+        assert w.is_constant()
+        assert w.initializer() == "{0}"
+
     def test_repr(self) -> None:
         assert repr(Variable(clang_parse("char x"))) == "<char x>"
 


### PR DESCRIPTION
## Summary
- Recognize typedefs that resolve to array types as arrays, by also checking the canonical type in `RenderableType.is_array`.
- Correctly detect `const` on a typedef-to-array variable (`const Foo bar` where `typedef T Foo[N]`), where the qualifier applies to the typedef rather than the element type.

Previously, `extern Foo bar;` (with `typedef uint8 Foo[4];`) was mocked as a scalar and produced an invalid initializer. `const Foo bar;` was additionally not flagged as constant.

## Test plan
- [x] New `test_typedef_array` — typedef-to-array is detected; initializer is `{0}`.
- [x] New `test_const_typedef_array` — `const` on the typedef is recognized; initializer is `{0}`.
- [x] Existing const/array tests still pass (87 passed).