### PR TITLE
chore: configure devcontainer proxy and host networking

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,9 @@ RUN rm -f /etc/apt/sources.list.d/yarn.list \
 
 RUN pip install --no-cache-dir uv
 
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV PIP_CERT=/etc/ssl/certs/ca-certificates.crt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,10 @@
 {
     "name": "hammocking",
     "build": {
-        "dockerfile": "Dockerfile"
+        "dockerfile": "Dockerfile",
+        "options": ["--network=host"]
     },
+    "runArgs": ["--network=host"],
     "initializeCommand": "mkdir -p .devcontainer/certs && cp /usr/local/share/ca-certificates/*.crt .devcontainer/certs/ 2>/dev/null; true",
     "features": {
         "ghcr.io/devcontainers/features/git:1": {},


### PR DESCRIPTION
## Summary
- Use host networking for the devcontainer build and runtime so builds work behind the corporate proxy
- Add missing CA-bundle env vars (`SSL_CERT_DIR`, `PIP_CERT`) so pip/curl/etc. trust the injected cert during build

## Test plan
- [x] Rebuild the devcontainer behind the proxy and confirm the build completes without SSL/network errors
- [x] Verify `pip install`, `curl`, and `npm`/`yarn` inside the container succeed